### PR TITLE
Add quotes to secret values

### DIFF
--- a/pkg/cmd/view-secret.go
+++ b/pkg/cmd/view-secret.go
@@ -168,7 +168,7 @@ func ProcessSecret(outWriter, errWriter io.Writer, secret map[string]interface{}
 	if decodeAll {
 		for _, k := range keys {
 			b64d, _ := base64.StdEncoding.DecodeString(data[k].(string))
-			_, _ = fmt.Fprintf(outWriter, "%s='%s'\n", k, strings.TrimSpace(string(b64d)))
+			_, _ = fmt.Fprintf(outWriter, "%s='%s' ", k, strings.TrimSpace(string(b64d)))
 		}
 	} else if len(data) == 1 {
 		for k, v := range data {

--- a/pkg/cmd/view-secret.go
+++ b/pkg/cmd/view-secret.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"sort"
+	"strings"
 
 	"github.com/goccy/go-json"
 	"github.com/spf13/cobra"
@@ -167,7 +168,7 @@ func ProcessSecret(outWriter, errWriter io.Writer, secret map[string]interface{}
 	if decodeAll {
 		for _, k := range keys {
 			b64d, _ := base64.StdEncoding.DecodeString(data[k].(string))
-			_, _ = fmt.Fprintf(outWriter, "%s=%s\n", k, b64d)
+			_, _ = fmt.Fprintf(outWriter, "%s=\\'%s\\'\n", k, strings.TrimSpace(string(b64d)))
 		}
 	} else if len(data) == 1 {
 		for k, v := range data {

--- a/pkg/cmd/view-secret.go
+++ b/pkg/cmd/view-secret.go
@@ -168,7 +168,7 @@ func ProcessSecret(outWriter, errWriter io.Writer, secret map[string]interface{}
 	if decodeAll {
 		for _, k := range keys {
 			b64d, _ := base64.StdEncoding.DecodeString(data[k].(string))
-			_, _ = fmt.Fprintf(outWriter, "%s=\\'%s\\'\n", k, strings.TrimSpace(string(b64d)))
+			_, _ = fmt.Fprintf(outWriter, "%s='%s'\n", k, strings.TrimSpace(string(b64d)))
 		}
 	} else if len(data) == 1 {
 		for k, v := range data {

--- a/pkg/cmd/view-secret.go
+++ b/pkg/cmd/view-secret.go
@@ -168,7 +168,7 @@ func ProcessSecret(outWriter, errWriter io.Writer, secret map[string]interface{}
 	if decodeAll {
 		for _, k := range keys {
 			b64d, _ := base64.StdEncoding.DecodeString(data[k].(string))
-			_, _ = fmt.Fprintf(outWriter, "%s='%s' ", k, strings.TrimSpace(string(b64d)))
+			_, _ = fmt.Fprintf(outWriter, "%s='%s'\n", k, strings.TrimSpace(string(b64d)))
 		}
 	} else if len(data) == 1 {
 		for k, v := range data {

--- a/pkg/cmd/view-secret_test.go
+++ b/pkg/cmd/view-secret_test.go
@@ -89,9 +89,9 @@ func TestProcessSecret(t *testing.T) {
 		"view-secret test -a": {
 			secret,
 			[]string{
-				"TEST_CONN_STR=\\'mongodb://myDBReader:D1fficultP%40ssw0rd@mongodb0.example.com:27017/?authSource=admin\\'",
-				"TEST_PASSWORD=\\'secret\\'",
-				"TEST_PASSWORD_2=\\'verysecret\\'",
+				"TEST_CONN_STR='mongodb://myDBReader:D1fficultP%40ssw0rd@mongodb0.example.com:27017/?authSource=admin'",
+				"TEST_PASSWORD='secret'",
+				"TEST_PASSWORD_2='verysecret'",
 			},
 			nil,
 			"",

--- a/pkg/cmd/view-secret_test.go
+++ b/pkg/cmd/view-secret_test.go
@@ -89,11 +89,9 @@ func TestProcessSecret(t *testing.T) {
 		"view-secret test -a": {
 			secret,
 			[]string{
-				"",
-				"",
-				"TEST_CONN_STR=mongodb://myDBReader:D1fficultP%40ssw0rd@mongodb0.example.com:27017/?authSource=admin",
-				"TEST_PASSWORD=secret",
-				"TEST_PASSWORD_2=verysecret",
+				"TEST_CONN_STR=\\'mongodb://myDBReader:D1fficultP%40ssw0rd@mongodb0.example.com:27017/?authSource=admin\\'",
+				"TEST_PASSWORD=\\'secret\\'",
+				"TEST_PASSWORD_2=\\'verysecret\\'",
 			},
 			nil,
 			"",


### PR DESCRIPTION
@elsesiy , please review these changes. 

This will print the output with quotes around the secret values. This is helpful is secret values have special characters to be parsed by other tools.

```
k view-secret mytest -a
TESTSECRET='testvalue'
TESTSECRET1='testvalue1'
```