### PR TITLE
Ease copy past of install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Instead you can now do:
 
 ### Krew
 
-This plugin is available through [krew](https://krew.dev) via :
+This plugin is available through [krew](https://krew.dev) via:
 
 ```sh
 kubectl krew install view-secret

--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ Instead you can now do:
 
 ### Krew
 
-This plugin is available through [krew](https://krew.dev) via `kubectl krew install view-secret`.
+This plugin is available through [krew](https://krew.dev) via :
+
+```sh
+kubectl krew install view-secret
+```
 
 ### Binary releases
 


### PR DESCRIPTION
Improve readme by easing the copy past of the the install command. The previous version required to manually select the command. This new version provides, the copy button and is on a single line.