### PR TITLE
Don't trim Secrets

### DIFF
--- a/pkg/cmd/view-secret.go
+++ b/pkg/cmd/view-secret.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"sort"
-	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
@@ -223,18 +222,18 @@ func ProcessSecret(outWriter, errWriter io.Writer, inputReader io.Reader, secret
 	if decodeAll {
 		for _, k := range keys {
 			b64d, _ := base64.StdEncoding.DecodeString(data[k])
-			_, _ = fmt.Fprintf(outWriter, "%s='%s'\n", k, strings.TrimSpace(string(b64d)))
+			_, _ = fmt.Fprintf(outWriter, "%s='%s'\n", k, string(b64d))
 		}
 	} else if len(data) == 1 {
 		for k, v := range data {
 			_, _ = fmt.Fprintf(errWriter, singleKeyDescription+"\n", k)
 			b64d, _ := base64.StdEncoding.DecodeString(v)
-			_, _ = fmt.Fprintf(outWriter, "%s\n", strings.TrimSpace(string(b64d)))
+			_, _ = fmt.Fprintf(outWriter, "%s\n", string(b64d))
 		}
 	} else if secretKey != "" {
 		if v, ok := data[secretKey]; ok {
 			b64d, _ := base64.StdEncoding.DecodeString(v)
-			_, _ = fmt.Fprintf(outWriter, "%s\n", strings.TrimSpace(string(b64d)))
+			_, _ = fmt.Fprintf(outWriter, "%s\n", string(b64d))
 		} else {
 			return ErrSecretKeyNotFound
 		}

--- a/pkg/cmd/view-secret_test.go
+++ b/pkg/cmd/view-secret_test.go
@@ -122,8 +122,8 @@ func TestProcessSecret(t *testing.T) {
 			secret,
 			[]string{
 				"TEST_CONN_STR='mongodb://myDBReader:D1fficultP%40ssw0rd@mongodb0.example.com:27017/?authSource=admin'",
-				"TEST_PASSWORD='secret'",
-				"TEST_PASSWORD_2='verysecret'",
+				"TEST_PASSWORD='secret\n'",
+				"TEST_PASSWORD_2='verysecret\n'",
 			},
 			[]string{},
 			"",
@@ -145,8 +145,8 @@ func TestProcessSecret(t *testing.T) {
 			secret,
 			[]string{
 				"TEST_CONN_STR='mongodb://myDBReader:D1fficultP%40ssw0rd@mongodb0.example.com:27017/?authSource=admin'",
-				"TEST_PASSWORD='secret'",
-				"TEST_PASSWORD_2='verysecret'",
+				"TEST_PASSWORD='secret\n'",
+				"TEST_PASSWORD_2='verysecret\n'",
 			},
 			nil,
 			"",


### PR DESCRIPTION
Fixes #44.

Currently, all secret values are trimmed with `strings.TrimSpace` (which also removes line breaks).
Since it is a common mistake to encode a password and add an unintended line break (for example, by using `echo "secret" | base64`), it is misleading to have these values trimmed.