### PR TITLE
Add support for helm secrets

### DIFF
--- a/hack/kind-bootstrap.sh
+++ b/hack/kind-bootstrap.sh
@@ -68,3 +68,25 @@ kind: Namespace
 metadata:
   name: empty
 EOF
+
+## 'helm' namespace
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: helm
+EOF
+
+## helm secret 'test3' in namespace 'helm' (single key)
+sec=$(echo "helm-test" | gzip -c | base64 | base64)
+kubectl apply -f - <<EOF
+apiVersion: v1
+data:
+  release: $sec
+kind: Secret
+metadata:
+  name: test3
+  namespace: helm
+type: helm.sh/release.v1
+EOF
+

--- a/pkg/cmd/decode.go
+++ b/pkg/cmd/decode.go
@@ -8,10 +8,12 @@ import (
 	"strings"
 )
 
+// SecretDecoder is an interface for decoding various kubernetes secret resources
 type SecretDecoder interface {
 	Decode(input string) (string, error)
 }
 
+// Decode decodes a secret based on its type, currently supporting only Opaque and Helm secrets
 func (s Secret) Decode(input string) (string, error) {
 	switch s.Type {
 	// TODO handle all secret types

--- a/pkg/cmd/decode.go
+++ b/pkg/cmd/decode.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"compress/gzip"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type SecretDecoder interface {
+	Decode(input string) (string, error)
+}
+
+func (s Secret) Decode(input string) (string, error) {
+	switch s.Type {
+	// TODO handle all secret types
+	case Opaque:
+		b64d, err := base64.StdEncoding.DecodeString(input)
+		if err != nil {
+			return "", nil
+		}
+		return string(b64d), nil
+	case Helm:
+		b64dk8s, _ := base64.StdEncoding.DecodeString(input)
+		b64dhelm, _ := base64.StdEncoding.DecodeString(string(b64dk8s))
+
+		gz, err := gzip.NewReader(strings.NewReader(string(b64dhelm)))
+		if err != nil {
+			return "", err
+		}
+		defer gz.Close()
+
+		s, err := io.ReadAll(gz)
+		if err != nil {
+			return "", err
+		}
+
+		return string(s), nil
+	}
+
+	return "", fmt.Errorf("couldn't decode unknown secret type %q", s.Type)
+}

--- a/pkg/cmd/decode.go
+++ b/pkg/cmd/decode.go
@@ -18,12 +18,18 @@ func (s Secret) Decode(input string) (string, error) {
 	case Opaque:
 		b64d, err := base64.StdEncoding.DecodeString(input)
 		if err != nil {
-			return "", nil
+			return "", err
 		}
 		return string(b64d), nil
 	case Helm:
-		b64dk8s, _ := base64.StdEncoding.DecodeString(input)
-		b64dhelm, _ := base64.StdEncoding.DecodeString(string(b64dk8s))
+		b64dk8s, err := base64.StdEncoding.DecodeString(input)
+		if err != nil {
+			return "", err
+		}
+		b64dhelm, err := base64.StdEncoding.DecodeString(string(b64dk8s))
+		if err != nil {
+			return "", err
+		}
 
 		gz, err := gzip.NewReader(strings.NewReader(string(b64dhelm)))
 		if err != nil {

--- a/pkg/cmd/decode_test.go
+++ b/pkg/cmd/decode_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecode(t *testing.T) {
+	tests := map[string]struct {
+		data func() Secret
+		want string
+	}{
+		// base64 encoded
+		"opaque": {
+			func() Secret {
+				return Secret{
+					Data: map[string]string{
+						"key": "dGVzdAo=",
+					},
+					Type: Opaque,
+				}
+			},
+			"test\n",
+		},
+		// double base64 encoded + gzip'd
+		"helm": {
+			func() Secret {
+				res := Secret{
+					Type: Helm,
+				}
+				var buf bytes.Buffer
+				gz := gzip.NewWriter(&buf)
+				if _, err := gz.Write([]byte("test\n")); err != nil {
+					return res
+				}
+				if err := gz.Close(); err != nil {
+					return res
+				}
+
+				b64k8s := base64.StdEncoding.EncodeToString(buf.Bytes())
+				b64helm := base64.StdEncoding.EncodeToString([]byte(b64k8s))
+
+				res.Data = SecretData{
+					"key": b64helm,
+				}
+
+				return res
+			},
+			"test\n",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			data := tt.data()
+			want := tt.want
+
+			got, err := data.Decode(data.Data["key"])
+			if err != nil {
+				t.Errorf("got %v, want %v", got, want)
+			}
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/cmd/decode_test.go
+++ b/pkg/cmd/decode_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,8 +12,9 @@ import (
 
 func TestDecode(t *testing.T) {
 	tests := map[string]struct {
-		data func() Secret
-		want string
+		data    func() Secret
+		want    string
+		wantErr error
 	}{
 		// base64 encoded
 		"opaque": {
@@ -25,6 +27,20 @@ func TestDecode(t *testing.T) {
 				}
 			},
 			"test\n",
+			nil,
+		},
+		// base64 encoded
+		"opaque invalid": {
+			func() Secret {
+				return Secret{
+					Data: map[string]string{
+						"key": "dGVzdAo}}}=",
+					},
+					Type: Opaque,
+				}
+			},
+			"",
+			base64.CorruptInputError(7),
 		},
 		// double base64 encoded + gzip'd
 		"helm": {
@@ -51,6 +67,16 @@ func TestDecode(t *testing.T) {
 				return res
 			},
 			"test\n",
+			nil,
+		},
+		"unknown secret": {
+			func() Secret {
+				return Secret{
+					Type: "invalid",
+				}
+			},
+			"",
+			errors.New("couldn't decode unknown secret type \"invalid\""),
 		},
 	}
 
@@ -59,11 +85,18 @@ func TestDecode(t *testing.T) {
 			t.Parallel()
 
 			data := tt.data()
-			want := tt.want
 
 			got, err := data.Decode(data.Data["key"])
 			if err != nil {
-				t.Errorf("got %v, want %v", got, want)
+				if tt.wantErr == nil {
+					assert.Fail(t, "unexpected error", err)
+				} else if err.Error() != tt.wantErr.Error() {
+					assert.Equal(t, tt.wantErr, err)
+				}
+				return
+			} else if tt.wantErr != nil {
+				assert.Fail(t, "expected error, got nil", tt.wantErr)
+				return
 			}
 
 			assert.Equal(t, tt.want, got)

--- a/pkg/cmd/types.go
+++ b/pkg/cmd/types.go
@@ -1,17 +1,21 @@
 package cmd
 
+// SecretList represents a list of secrets
 type SecretList struct {
 	Items []Secret `json:"items"`
 }
 
+// Secret represents a kubernetes secret
 type Secret struct {
 	Data     SecretData `json:"data"`
 	Metadata Metadata   `json:"metadata"`
 	Type     SecretType `json:"type"`
 }
 
+// SecretData represents the data of a secret
 type SecretData map[string]string
 
+// Metadata represents the metadata of a secret
 type Metadata struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`

--- a/pkg/cmd/types.go
+++ b/pkg/cmd/types.go
@@ -7,6 +7,7 @@ type SecretList struct {
 type Secret struct {
 	Data     SecretData `json:"data"`
 	Metadata Metadata   `json:"metadata"`
+	Type     SecretType `json:"type"`
 }
 
 type SecretData map[string]string
@@ -15,3 +16,32 @@ type Metadata struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
 }
+
+// SecretType represents the type of a secret
+//
+// Opaque	arbitrary user-defined data
+// kubernetes.io/service-account-token	ServiceAccount token
+// kubernetes.io/dockercfg	serialized ~/.dockercfg file
+// kubernetes.io/dockerconfigjson	serialized ~/.docker/config.json file
+// kubernetes.io/basic-auth	credentials for basic authentication
+// kubernetes.io/ssh-auth	credentials for SSH authentication
+// kubernetes.io/tls	data for a TLS client or server
+// bootstrap.kubernetes.io/token	bootstrap token data
+// helm.sh/release.v1	Helm v3 release data
+//
+// refs:
+// - https://kubernetes.io/docs/concepts/configuration/secret/#secret-types
+// - https://gist.github.com/DzeryCZ/c4adf39d4a1a99ae6e594a183628eaee
+type SecretType string
+
+const (
+	BasicAuth           SecretType = "kubernetes.io/basic-auth"
+	DockerCfg           SecretType = "kubernetes.io/dockercfg"
+	DockerConfigJson    SecretType = "kubernetes.io/dockerconfigjson"
+	Helm                SecretType = "helm.sh/release.v1"
+	Opaque              SecretType = "Opaque"
+	ServiceAccountToken SecretType = "kubernetes.io/service-account-token"
+	SshAuth             SecretType = "kubernetes.io/ssh-auth"
+	Tls                 SecretType = "kubernetes.io/tls"
+	Token               SecretType = "bootstrap.kubernetes.io/token"
+)

--- a/pkg/cmd/types_test.go
+++ b/pkg/cmd/types_test.go
@@ -58,7 +58,7 @@ func TestSerialize(t *testing.T) {
 		want    Secret
 		wantErr error
 	}{
-		"empty opqague secret": {
+		"empty opaque secret": {
 			input: invalidSecretJson,
 			want: Secret{
 				Metadata: Metadata{
@@ -69,7 +69,7 @@ func TestSerialize(t *testing.T) {
 			},
 			wantErr: errors.New("invalid character '}' looking for beginning of object key string"),
 		},
-		"valid opague secret": {
+		"valid opaque secret": {
 			input: validSecretJson,
 			want: Secret{
 				Data: SecretData{

--- a/pkg/cmd/types_test.go
+++ b/pkg/cmd/types_test.go
@@ -11,45 +11,48 @@ import (
 
 var (
 	validSecretJson = `{
-    "apiVersion": "v1",
-    "data": {
-        "key1": "dmFsdWUxCg==",
-        "key2": "dmFsdWUyCg=="
-    },
-    "kind": "Secret",
-    "metadata": {
-        "creationTimestamp": "2024-08-02T21:25:40Z",
-        "name": "test",
-        "namespace": "default",
-        "resourceVersion": "715",
-        "uid": "0027fdc9-5371-4715-a0a8-61f3f78fdd36"
-    },
-    "type": "Opaque"
-}`
+  "apiVersion": "v1",
+  "data": {
+    "key1": "dmFsdWUxCg==",
+    "key2": "dmFsdWUyCg=="
+  },
+  "kind": "Secret",
+  "metadata": {
+    "creationTimestamp": "2024-08-02T21:25:40Z",
+    "name": "test",
+    "namespace": "default",
+    "resourceVersion": "715",
+    "uid": "0027fdc9-5371-4715-a0a8-61f3f78fdd36"
+  },
+  "type": "Opaque"
+}
+`
 
 	helmSecretJson = `{
-	  "apiVersion": "v1",
-	   "data": {
-         "release": "blob"
-		 },
-	   "kind": "Secret",
-	   "metadata": {
-	       "name": "sh.helm.release.v1.wordpress.v1",
-	       "namespace": "default"
-	   },
-	   "type": "helm.sh/release.v1"
-	}`
+  "apiVersion": "v1",
+  "data": {
+    "release": "blob"
+  },
+  "kind": "Secret",
+  "metadata": {
+    "name": "sh.helm.release.v1.wordpress.v1",
+    "namespace": "default"
+  },
+  "type": "helm.sh/release.v1"
+}
+`
 
 	invalidSecretJson = `{
-    "apiVersion": "v1",
-    "data": {},
-    "kind": "Secret",
-    "metadata": {
-        "name": "test-empty",
-        "namespace": "default",
-    },
-    "type": "Opaque"
-}`
+  "apiVersion": "v1",
+  "data": {},
+  "kind": "Secret",
+  "metadata": {
+    "name": "test-empty",
+    "namespace": "default",
+  },
+  "type": "Opaque"
+}
+`
 )
 
 func TestSerialize(t *testing.T) {

--- a/pkg/cmd/types_test.go
+++ b/pkg/cmd/types_test.go
@@ -27,7 +27,20 @@ var (
     "type": "Opaque"
 }`
 
-	emptySecretJson = `{
+	helmSecretJson = `{
+	  "apiVersion": "v1",
+	   "data": {
+         "release": "blob"
+		 },
+	   "kind": "Secret",
+	   "metadata": {
+	       "name": "sh.helm.release.v1.wordpress.v1",
+	       "namespace": "default"
+	   },
+	   "type": "helm.sh/release.v1"
+	}`
+
+	invalidSecretJson = `{
     "apiVersion": "v1",
     "data": {},
     "kind": "Secret",
@@ -45,17 +58,18 @@ func TestSerialize(t *testing.T) {
 		want    Secret
 		wantErr error
 	}{
-		"empty secret": {
-			input: emptySecretJson,
+		"empty opqague secret": {
+			input: invalidSecretJson,
 			want: Secret{
 				Metadata: Metadata{
 					Name:      "test",
 					Namespace: "default",
 				},
+				Type: Opaque,
 			},
 			wantErr: errors.New("invalid character '}' looking for beginning of object key string"),
 		},
-		"valid secret": {
+		"valid opague secret": {
 			input: validSecretJson,
 			want: Secret{
 				Data: SecretData{
@@ -66,6 +80,20 @@ func TestSerialize(t *testing.T) {
 					Name:      "test",
 					Namespace: "default",
 				},
+				Type: Opaque,
+			},
+		},
+		"valid helm secret": {
+			input: helmSecretJson,
+			want: Secret{
+				Data: SecretData{
+					"release": "blob",
+				},
+				Metadata: Metadata{
+					Name:      "sh.helm.release.v1.wordpress.v1",
+					Namespace: "default",
+				},
+				Type: Helm,
 			},
 		},
 	}

--- a/pkg/cmd/view-secret.go
+++ b/pkg/cmd/view-secret.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -221,19 +220,19 @@ func ProcessSecret(outWriter, errWriter io.Writer, inputReader io.Reader, secret
 
 	if decodeAll {
 		for _, k := range keys {
-			b64d, _ := base64.StdEncoding.DecodeString(data[k])
-			_, _ = fmt.Fprintf(outWriter, "%s='%s'\n", k, string(b64d))
+			s, _ := secret.Decode(data[k])
+			_, _ = fmt.Fprintf(outWriter, "%s='%s'\n", k, s)
 		}
 	} else if len(data) == 1 {
 		for k, v := range data {
 			_, _ = fmt.Fprintf(errWriter, singleKeyDescription+"\n", k)
-			b64d, _ := base64.StdEncoding.DecodeString(v)
-			_, _ = fmt.Fprintf(outWriter, "%s\n", string(b64d))
+			s, _ := secret.Decode(v)
+			_, _ = fmt.Fprintf(outWriter, "%s\n", s)
 		}
 	} else if secretKey != "" {
 		if v, ok := data[secretKey]; ok {
-			b64d, _ := base64.StdEncoding.DecodeString(v)
-			_, _ = fmt.Fprintf(outWriter, "%s\n", string(b64d))
+			s, _ := secret.Decode(v)
+			_, _ = fmt.Fprintf(outWriter, "%s\n", s)
 		} else {
 			return ErrSecretKeyNotFound
 		}

--- a/pkg/cmd/view-secret_test.go
+++ b/pkg/cmd/view-secret_test.go
@@ -62,6 +62,7 @@ func TestNewCmdViewSecret(t *testing.T) {
 		"custom ns (does not exist)": {args: []string{"test", "--namespace", "bob"}, want: `Error from server (NotFound): namespaces "bob" not found`},
 		"custom ns (no secret)":      {args: []string{"test", "--namespace", "another"}, want: `Error from server (NotFound): secrets "test" not found`},
 		"custom ns (valid secret)":   {args: []string{"gopher", "--namespace", "another"}, want: `Viewing only available key: foo\nbar`},
+		"helm":                       {args: []string{"test3", "--namespace", "helm"}, want: `Viewing only available key: release\nhelm-test`},
 		"impersonate group":          {args: []string{"test", "--as", "gopher"}},
 		"impersonate user & group":   {args: []string{"test", "--as", "gopher", "--as-group", "golovers"}},
 		// make bootstrap sources 2 test secrets in the default namespace, select the first one and print all values

--- a/pkg/cmd/view-secret_test.go
+++ b/pkg/cmd/view-secret_test.go
@@ -22,6 +22,11 @@ var (
 		"SINGLE_PASSWORD": "c2VjcmV0Cg==",
 	}
 
+	// echo "helm-test" | gzip -c | base64 | base64
+	secretHelm = SecretData{
+		"release": "SDRzSUFGb2FlR2NBQTh0SXpjblZMVWt0THVFQ0FQdWt3aHdLQUFBQQo=",
+	}
+
 	secretEmpty = SecretData{}
 )
 
@@ -112,6 +117,7 @@ func TestNewCmdViewSecret(t *testing.T) {
 func TestProcessSecret(t *testing.T) {
 	tests := map[string]struct {
 		secretData SecretData
+		secretType SecretType
 		wantStdOut []string
 		wantStdErr []string
 		secretKey  string
@@ -121,6 +127,7 @@ func TestProcessSecret(t *testing.T) {
 	}{
 		"view-secret <secret>": {
 			secret,
+			Opaque,
 			[]string{
 				"TEST_CONN_STR='mongodb://myDBReader:D1fficultP%40ssw0rd@mongodb0.example.com:27017/?authSource=admin'",
 				"TEST_PASSWORD='secret\n'",
@@ -134,6 +141,7 @@ func TestProcessSecret(t *testing.T) {
 		},
 		"view-secret <secret-single-key>": {
 			secretSingle,
+			Opaque,
 			[]string{"secret"},
 			[]string{fmt.Sprintf(singleKeyDescription, "SINGLE_PASSWORD")},
 			"",
@@ -141,9 +149,29 @@ func TestProcessSecret(t *testing.T) {
 			nil,
 			"",
 		},
-		"view-secret test TEST_PASSWORD": {secret, []string{"secret"}, nil, "TEST_PASSWORD", false, nil, ""},
+		"view-secret <helm-secret>": {
+			secretHelm,
+			Helm,
+			[]string{"helm-test"},
+			[]string{fmt.Sprintf(singleKeyDescription, "release")},
+			"",
+			false,
+			nil,
+			"",
+		},
+		"view-secret test TEST_PASSWORD": {
+			secret,
+			Opaque,
+			[]string{"secret"},
+			nil,
+			"TEST_PASSWORD",
+			false,
+			nil,
+			"",
+		},
 		"view-secret test -a": {
 			secret,
+			Opaque,
 			[]string{
 				"TEST_CONN_STR='mongodb://myDBReader:D1fficultP%40ssw0rd@mongodb0.example.com:27017/?authSource=admin'",
 				"TEST_PASSWORD='secret\n'",
@@ -155,8 +183,26 @@ func TestProcessSecret(t *testing.T) {
 			nil,
 			"",
 		},
-		"view-secret test NONE":      {secret, nil, nil, "NONE", false, ErrSecretKeyNotFound, ""},
-		"view-secret <secret-empty>": {secretEmpty, nil, nil, "", false, ErrSecretEmpty, ""},
+		"view-secret test NONE": {
+			secret,
+			Opaque,
+			nil,
+			nil,
+			"NONE",
+			false,
+			ErrSecretKeyNotFound,
+			"",
+		},
+		"view-secret <secret-empty>": {
+			secretEmpty,
+			Opaque,
+			nil,
+			nil,
+			"",
+			false,
+			ErrSecretEmpty,
+			"",
+		},
 	}
 
 	for name, test := range tests {
@@ -171,7 +217,7 @@ func TestProcessSecret(t *testing.T) {
 				readBuf = *strings.NewReader(test.feedkeys)
 			}
 
-			err := ProcessSecret(&stdOutBuf, &stdErrBuf, &readBuf, Secret{Data: test.secretData, Type: Opaque}, test.secretKey, test.decodeAll)
+			err := ProcessSecret(&stdOutBuf, &stdErrBuf, &readBuf, Secret{Data: test.secretData, Type: test.secretType}, test.secretKey, test.decodeAll)
 
 			if test.err != nil {
 				assert.Equal(t, err, test.err)

--- a/pkg/cmd/view-secret_test.go
+++ b/pkg/cmd/view-secret_test.go
@@ -170,7 +170,7 @@ func TestProcessSecret(t *testing.T) {
 				readBuf = *strings.NewReader(test.feedkeys)
 			}
 
-			err := ProcessSecret(&stdOutBuf, &stdErrBuf, &readBuf, Secret{Data: test.secretData}, test.secretKey, test.decodeAll)
+			err := ProcessSecret(&stdOutBuf, &stdErrBuf, &readBuf, Secret{Data: test.secretData, Type: Opaque}, test.secretKey, test.decodeAll)
 
 			if test.err != nil {
 				assert.Equal(t, err, test.err)


### PR DESCRIPTION
Prior to this change, the plugin always assumed secrets to be of type `Opaque`. This change introduces the secret type for (de)serialization and adds a small interface that is used to keep the core logic mostly unchanged but handle different types of secrets. Only support for helm was added for now but expanding to more types should be straight-forward

Fixes #50