### PR TITLE
Add decode default case for unhandled types

### DIFF
--- a/pkg/cmd/decode.go
+++ b/pkg/cmd/decode.go
@@ -45,7 +45,12 @@ func (s Secret) Decode(input string) (string, error) {
 		}
 
 		return string(s), nil
+	default:
+		// Attempt to decode without specific type handling
+		b64d, err := base64.StdEncoding.DecodeString(input)
+		if err != nil {
+			return "", fmt.Errorf("couldn't decode unknown secret type %q: %w", s.Type, err)
+		}
+		return string(b64d), nil
 	}
-
-	return "", fmt.Errorf("couldn't decode unknown secret type %q", s.Type)
 }

--- a/pkg/cmd/decode_test.go
+++ b/pkg/cmd/decode_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -69,14 +68,18 @@ func TestDecode(t *testing.T) {
 			"test\n",
 			nil,
 		},
-		"unknown secret": {
+		// basic auth via default case
+		"basic auth": {
 			func() Secret {
 				return Secret{
-					Type: "invalid",
+					Data: map[string]string{
+						"key": "dGVzdAo=",
+					},
+					Type: BasicAuth,
 				}
 			},
-			"",
-			errors.New("couldn't decode unknown secret type \"invalid\""),
+			"test\n",
+			nil,
 		},
 	}
 


### PR DESCRIPTION
https://github.com/elsesiy/kubectl-view-secret/pull/54 introduced a small regression where only specific types where handled. Instead, we're now always decoding if there is no specific type handling

Fix #55