### PR TITLE
Fix single key text output formatting

### DIFF
--- a/pkg/cmd/view-secret.go
+++ b/pkg/cmd/view-secret.go
@@ -393,8 +393,22 @@ func outputYAML(outWriter io.Writer, secret Secret, decodedData map[string]strin
 
 // outputText outputs secret data as plain text
 func outputText(outWriter io.Writer, decodedData map[string]string) error {
+	var format string
+
+	if len(decodedData) == 1 {
+		format = "%s\n"
+	} else {
+		format = "%s='%s'\n"
+	}
+
 	for k, v := range decodedData {
-		if _, err := fmt.Fprintf(outWriter, "%s='%s'\n", k, v); err != nil {
+		var args []any
+		if len(decodedData) == 1 {
+			args = []any{v}
+		} else {
+			args = []any{k, v}
+		}
+		if _, err := fmt.Fprintf(outWriter, format, args...); err != nil {
 			return fmt.Errorf("failed to write output: %w", err)
 		}
 	}

--- a/pkg/cmd/view-secret_test.go
+++ b/pkg/cmd/view-secret_test.go
@@ -282,6 +282,31 @@ func TestErrorHandling(t *testing.T) {
 	}
 }
 
+func TestOutputText(t *testing.T) {
+	tests := map[string]struct {
+		decodedData map[string]string
+		want        string
+	}{
+		"single key": {
+			map[string]string{"key": "value"},
+			"value\n",
+		},
+		"multiple keys": {
+			map[string]string{"key1": "value1", "key2": "value2"},
+			"key1='value1'\nkey2='value2'\n",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := outputText(&buf, tt.decodedData)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, buf.String())
+		})
+	}
+}
+
 func TestCompletionFlagRegistration(t *testing.T) {
 	cmd := NewCmdViewSecret()
 


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/elsesiy/kubectl-view-secret/pull/65 that would result in text output formatting to always include the secret key which makes it hard to parse.

Thanks you @glitchcrab for reporting this issue.

Fix #71