### PR TITLE
Update goreleaser manifest

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,10 @@
 ---
+archives:
+  - ids:
+      - kubectl-view-secret
+    name_template: '{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    wrap_in_directory: false
+    formats: [tar.gz]
 before:
   hooks:
     - go mod download
@@ -16,9 +22,4 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
-archives:
-  - builds:
-      - kubectl-view-secret
-    name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
-    wrap_in_directory: false
-    format: tar.gz
+version: 2


### PR DESCRIPTION
Replaces deprecated settings

```
❯ goreleaser check
  • checking                                  path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!
```

Fix #76 